### PR TITLE
Change baseDirectory for build error

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -11,7 +11,7 @@ frontend:
       commands:
         - npm run build
   artifacts:
-    baseDirectory: build-logs
+    baseDirectory: dist
     files:
       - '**/*'
   cache:


### PR DESCRIPTION
See if this allows a build. If it does, we have a set CI pipeline. And then I am going to test our a redirect for the 'npm run build' command. And if that doesn't work we can revert to this.