### PR TITLE
Add specific naming

### DIFF
--- a/amplify/data/resource.ts
+++ b/amplify/data/resource.ts
@@ -10,11 +10,13 @@ specifies that any user authenticated via an API key can "create", "read",
 =========================================================================*/
 
 const spoonacularHandler = defineFunction({
+  name: "spoonacularHandler",
   entry: "../functions/spoonacular/handler.ts",
-})
+});
 const saveFavoriteHandler = defineFunction({
+  name: "saveFavoriteHandler",
   entry: "../functions/saveFavoriteRecipe/handler.ts",
-})
+});
 
 const schema = a.schema({
   // GetRecipeResponse: a.customType({


### PR DESCRIPTION
Add specific names for error message: 
BackendSynthError: Unable to build the Amplify backend definition.
Resolution: Check your backend definition in the `amplify` folder for syntax and type errors.
Cause: Error: There is already a Construct with name 'handler' in NestedStack [function]