### PR TITLE
Fix api construct error

### DIFF
--- a/amplify/data/resource.ts
+++ b/amplify/data/resource.ts
@@ -86,7 +86,7 @@ const schema = a.schema({
     // FCan include the return type:
     // .returns(a.ref("GetRecipeResponse").required())
     // .authorization((allow) => [allow.authenticated()])
-    .authorization((allow) => [allow.publicApiKey()])
+    .authorization((allow) => [allow.authenticated()])
     .handler(a.handler.function(spoonacularHandler)),
 
   SaveFavoriteRecipe: a
@@ -189,7 +189,7 @@ const schema = a.schema({
     .authorization((allow) => [allow.owner()]),
 
 }) // <-- .schema
-.authorization((allow) => [allow.publicApiKey()]);
+.authorization((allow) => [allow.authenticated()]);
 
 export type Schema = ClientSchema<typeof schema>;
 


### PR DESCRIPTION
Fix error on data api construct:

AmplifyDataConstructInitializationError: Failed to instantiate data construct
Resolution: See the underlying error message for more details.
Cause: @auth directive with 'apiKey' provider found, but the project has no API Key authentication provider configured.