### PR TITLE
Using secret instead of env

### DIFF
--- a/amplify/backend.ts
+++ b/amplify/backend.ts
@@ -19,7 +19,7 @@ const spoon_httpDataSource = backend.data.addHttpDataSource(
     authorizationConfig: {
       signingRegion: 'us-east-1',
       signingServiceName: 'appsync',
-    },
+    }
   }
 );
 

--- a/amplify/data/getComplexRecipe.js
+++ b/amplify/data/getComplexRecipe.js
@@ -1,4 +1,5 @@
 import { util } from '@aws-appsync/utils';
+import { secret } from '@aws-amplify/backend';
 
 export function request(ctx) {
     const { path, httpMethod, queryStringParameters, pathParameters } = ctx.arguments;
@@ -12,7 +13,7 @@ export function request(ctx) {
     // Add API key to query parameters
     const params = {
         ...queryStringParameters,
-        apiKey: process.env.SPOONACULAR_API_KEY,
+        apiKey: secret('SPOONACULAR_API_KEY'),
     };
 
     // Convert params to URL query string


### PR DESCRIPTION
Switch to secret instead of env due to AppSync Resolver errors in build

